### PR TITLE
Fix pkgver, always use version for steamguard-cli

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,7 +15,7 @@ sha256sums=('SKIP')
 
 pkgver() {
     cd "${srcdir}/${_pkgname}"
-    git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/v//g'
+    git describe --long --tags --match 'v*' | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/v//g'
 }
 
 build() {


### PR DESCRIPTION
Instead of using the tag name of steamguard (steamguard-vX.X.X), use the tag for steamguard-cli (vX.X.X).